### PR TITLE
Feature/1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.5
+
+* Add exports to `magic_the_gathering_flutter.dart` for simpler importing.
+* Update the `README.md` with documentation for `mtgSymbology` and `MTGCardFace`
+* Update the example project to import the library file directly and bump the example's version to 1.0.1
+
 ## 1.0.4
 
 * Remove [equatable](https://pub.dev/packages/equatable) as a dependency. The `==` and `hashCode` for the relevant classes are now manually overridden, using [collection](https://pub.dev/packages/collection) when necessary.

--- a/README.md
+++ b/README.md
@@ -54,13 +54,6 @@ A default constructor is not currently supported for the `MTGCard` model. The re
 
 ### MTGCard
 
-#### Methods
-
-| Method             | Description                                            | Return Type     |
-| :----------------- | :----------------------------------------------------- | :-------------- |
-| preparedManaCost   | Displays the card's mana cost using MTG symbol SVGs    | `List<Widget>?` |
-| preparedOracleText | Displays the card's oracle text using MTG symbol SVGs  | `TextSpan?`     |
-
 #### Properties
 
 | Property           | Description                                            | Return Type     |
@@ -68,6 +61,17 @@ A default constructor is not currently supported for the `MTGCard` model. The re
 | hasMultipleFaces   | Whether the card object has more than one face         | `bool`          |
 | sizeRatio          | The ratio of an MTG card's height to its width         | `double`        |
 | cornerRatio        | The ratio of an MTG card's height to its corner radius | `int`           |
+
+### MTGCardFace
+
+[MTGCard](https://pub.dev/documentation/magic_the_gathering_flutter/latest/models_mtg_card/MTGCard-class.html) extends [MTGCardFace](https://pub.dev/documentation/magic_the_gathering_flutter/latest/models_mtg_card_face/MTGCardFace-class.html), so all its methods are accessible from [MTGCard](https://pub.dev/documentation/magic_the_gathering_flutter/latest/models_mtg_card/MTGCard-class.html) instances as well.
+
+#### Methods
+
+| Method             | Description                                            | Return Type     |
+| :----------------- | :----------------------------------------------------- | :-------------- |
+| preparedManaCost   | Displays the card's mana cost using MTG symbol SVGs    | `List<Widget>?` |
+| preparedOracleText | Displays the card's oracle text using MTG symbol SVGs  | `TextSpan?`     |
 
 ### MTGSymbol
 
@@ -82,6 +86,13 @@ A default constructor is not currently supported for the `MTGCard` model. The re
 | Property           | Description                                            | Return Type     |
 | :----------------- | :----------------------------------------------------- | :-------------- |
 | regex              | Matches text that can be converted to an MTGSymbol     | `RegExp`        |
+
+### mtgSymbology
+
+A [Map](https://api.dart.dev/dart-core/Map-class.html) of [String](https://api.dart.dev/dart-core/String-class.html) keys and [MTGSymbol](https://pub.dev/documentation/magic_the_gathering_flutter/latest/models_mtg_symbology/MTGSymbol-class.html) instance values.
+The keys are based on the notation used in Magic: The Gathering's [Comprehensive Rules](https://magic.wizards.com/en/rules).
+
+The [MTGCardFace.preparedManaCost](https://pub.dev/documentation/magic_the_gathering_flutter/latest/models_mtg_card_face/MTGCardFace/preparedManaCost.html) method and the [MTGCardFace.preparedOracleText](https://pub.dev/documentation/magic_the_gathering_flutter/latest/models_mtg_card_face/MTGCardFace/preparedOracleText.html) method use this under the hood.
 
 ## Example
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
-import 'package:magic_the_gathering_flutter/models/mtg_card.dart';
+import 'package:magic_the_gathering_flutter/magic_the_gathering_flutter.dart';
 
 void main() {
   runApp(const MyApp());

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: example
 description: "A Flutter project to demonstrate the use of the magic_the_gathering_flutter package."
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.1+1
 
 environment:
   sdk: ^3.6.0

--- a/lib/magic_the_gathering_flutter.dart
+++ b/lib/magic_the_gathering_flutter.dart
@@ -1,1 +1,11 @@
+/// A library for helping render Magic: The Gathering cards and symbols as
+/// Flutter widgets.
+///
+/// See [here](https://pub.dev/packages/magic_the_gathering_flutter/example)
+/// for a full example.
 library;
+
+export 'enums/rarity.dart';
+export 'models/mtg_card.dart';
+export 'models/mtg_card_face.dart';
+export 'models/mtg_symbology.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_the_gathering_flutter
 description: Develop MTG Flutter apps with ease. Fully interoperable with the Scryfall API or your own custom JSON.
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/zmuranaka/magic_the_gathering_flutter
 issue_tracker: https://github.com/zmuranaka/magic_the_gathering_flutter/issues
 


### PR DESCRIPTION
* Add exports to `magic_the_gathering_flutter.dart` for simpler importing.
* Update the `README.md` with documentation for `mtgSymbology` and `MTGCardFace`
* Update the example project to import the library file directly and bump the example's version to 1.0.1