### PR TITLE
Feature/2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.4 - March 19, 2026
+
+* Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg) and [mtg_symbology](https://pub.dev/packages/mtg_symbology) dependency versions
+* Make minimum supported SDK version Flutter 3.35/Dart 3.9 - in line with [flutter_svg](https://github.com/flutter/packages/blob/8dcfd1186ef968be1398f80432f94bb0a36e6d9e/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
+* Upgrade [test](https://pub.dev/packages/test) and [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency versions
+
 ## 2.0.3 - February 22, 2026
 
 * Upgrade [mtg_symbology](https://pub.dev/packages/mtg_symbology) dependency version

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,19 +2,19 @@ name: magic_the_gathering_flutter
 description: "Develop Magic: The Gathering Flutter apps with ease. Fully interoperable with the Scryfall API or your own custom JSON."
 repository: https://github.com/zmuranaka/magic_the_gathering_flutter
 issue_tracker: https://github.com/zmuranaka/magic_the_gathering_flutter/issues
-version: 2.0.3
+version: 2.0.4
 
 environment:
-  sdk: ^3.8.0
-  flutter: ">=3.32.0"
+  sdk: ^3.9.0
+  flutter: ">=3.35.0"
 
 dependencies:
   collection: ^1.19.1
   flutter:
     sdk: flutter
-  flutter_svg: ^2.2.3
-  mtg_symbology: ^1.0.4
+  flutter_svg: ^2.2.4
+  mtg_symbology: ^1.0.5
 
 dev_dependencies:
-  test: ^1.29.0
-  very_good_analysis: ^10.0.0
+  test: ^1.31.0
+  very_good_analysis: ^10.2.0


### PR DESCRIPTION
* Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg) and [mtg_symbology](https://pub.dev/packages/mtg_symbology) dependency versions
* Make minimum supported SDK version Flutter 3.35/Dart 3.9 - in line with [flutter_svg](https://github.com/flutter/packages/blob/8dcfd1186ef968be1398f80432f94bb0a36e6d9e/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
* Upgrade [test](https://pub.dev/packages/test) and [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency versions