### PR TITLE
2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.5 - July 3, 2026
+
+* Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg) and [mtg_symbology](https://pub.dev/packages/mtg_symbology) dependency versions
+* Make minimum supported SDK version Flutter 3.38/Dart 3.10 - in line with [flutter_svg](https://github.com/flutter/packages/blob/2fbe8734f450cb193b110851f9fc651290623398/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
+* Upgrade [test](https://pub.dev/packages/test) and [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency versions
+
 ## 2.0.4 - March 19, 2026
 
 * Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg) and [mtg_symbology](https://pub.dev/packages/mtg_symbology) dependency versions

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+android.builtInKotlin=false
+android.newDsl=false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,19 +2,19 @@ name: magic_the_gathering_flutter
 description: "Develop Magic: The Gathering Flutter apps with ease. Fully interoperable with the Scryfall API or your own custom JSON."
 repository: https://github.com/zmuranaka/magic_the_gathering_flutter
 issue_tracker: https://github.com/zmuranaka/magic_the_gathering_flutter/issues
-version: 2.0.4
+version: 2.0.5
 
 environment:
-  sdk: ^3.9.0
-  flutter: ">=3.35.0"
+  sdk: ^3.10.0
+  flutter: ">=3.38.0"
 
 dependencies:
   collection: ^1.19.1
   flutter:
     sdk: flutter
-  flutter_svg: ^2.2.4
-  mtg_symbology: ^1.0.5
+  flutter_svg: ^2.3.0
+  mtg_symbology: ^1.0.6
 
 dev_dependencies:
-  test: ^1.31.0
-  very_good_analysis: ^10.2.0
+  test: ^1.31.2
+  very_good_analysis: ^10.3.0


### PR DESCRIPTION
* Upgrade [flutter_svg](https://pub.dev/packages/flutter_svg) and [mtg_symbology](https://pub.dev/packages/mtg_symbology) dependency versions
* Make minimum supported SDK version Flutter 3.38/Dart 3.10 - in line with [flutter_svg](https://github.com/flutter/packages/blob/2fbe8734f450cb193b110851f9fc651290623398/third_party/packages/flutter_svg/pubspec.yaml#L8-L9)
* Upgrade [test](https://pub.dev/packages/test) and [very_good_analysis](https://pub.dev/packages/very_good_analysis) dev dependency versions
* An auto-generated change to `example/android/gradle.properties` from running the example app to Android